### PR TITLE
Add patch/command to ignore smartphone navigating status

### DIFF
--- a/Modifications/Lsd/NavActiveIgnore.jar
+++ b/Modifications/Lsd/NavActiveIgnore.jar
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:115ed7618194157955e9bbd6061c2629951ae30c910a5636e4c3562d948c5984
+size 23733

--- a/Toolbox/GEM/mqb-navigation.esd
+++ b/Toolbox/GEM/mqb-navigation.esd
@@ -42,6 +42,10 @@ script
    value   sys 1 0x0100 "/eso/hmi/engdefs/scripts/mqb/patch_mapstylestoSD_PO.sh"
    label   "Use Porsche mapstyles from SD-card"
 
+script
+   value   sys 1 0x0100 "/eso/hmi/engdefs/scripts/mqb/install_nav_active_ignore.sh"
+   label   "Ignore navigation-active status from smartphone"
+
 
 keyValue
     value   String sys 0x00000000 0

--- a/Toolbox/scripts/install_nav_active_ignore.sh
+++ b/Toolbox/scripts/install_nav_active_ignore.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+export PATH=/proc/boot:/bin:/usr/bin:/usr/sbin:/sbin:/mnt/app/media/gracenote/bin:/mnt/app/armle/bin:/mnt/app/armle/sbin:/mnt/app/armle/usr/bin:/mnt/app/armle/usr/sbin:$PATH
+
+if [ "$_" = "/bin/on" ]; then BASE="$0"; else BASE="$_"; fi
+SCRIPTDIR=$( cd -P -- "$(dirname -- "$(command -v -- "$BASE")")" && pwd -P )
+
+export LD_LIBRARY_PATH=/net/mmx/mnt/app/root/lib-target:/net/mmx/eso/lib:/net/mmx/mnt/app/usr/lib:/net/mmx/mnt/app/armle/lib:/net/mmx/mnt/app/armle/lib/dll:/net/mmx/mnt/app/armle/usr/lib
+
+. ${SCRIPTDIR}/util_mountsd.sh
+if [[ -z "$VOLUME" ]] 
+then
+  echo "No SD-card found, quitting"
+  exit 0
+fi
+
+mount -uw /mnt/app
+
+JAR_TARGET=/mnt/app/eso/hmi/lsd/jars/
+mkdir -p ${JAR_TARGET}
+
+cp -v ${VOLUME}/Modifications/Lsd/NavActiveIgnore.jar ${JAR_TARGET}
+
+LSD=/mnt/app/eso/hmi/lsd/lsd.sh
+BU=/mnt/app/eso/hmi/lsd/lsd.sh.bu
+
+if [ -e $BU ]; then
+mv $BU $LSD
+fi
+
+if ! grep -q NavActiveIgnore.jar ${LSD}; then
+if [ ! -e $BU ]; then
+  echo "Backup lsd.sh"
+  cp -v $LSD $BU
+fi
+echo "Patching lsd.sh to run NavActiveIgnore.jar"
+sed -ir 's,^$J9,BOOTCLASSPATH="$BOOTCLASSPATH -Xbootclasspath/p:$BASE_DIR/lsd/jars/NavActiveIgnore.jar"\n$J9,g' $LSD
+fi
+
+mount -ur /mnt/app
+echo "Done, please restart headunit"


### PR DESCRIPTION
Adds a command: `Advanced` -> `Navigation` -> `Ignore navigation-active status from smartphone`

This installs some java code to "break" in interlock between internal navigation and Android Auto navigation.

This means you can use navigation on Android Auto and still show internal nav on the Virtual Console.

Tip: turn off voice on one / both systems else they may try to talk over one another if you set navagation destinations on both systems.

For more details see:
* https://github.com/jilleb/mib2-toolbox/issues/10#issuecomment-1002301850
* https://github.com/jilleb/mib2-toolbox/issues/10#issuecomment-1001510035

Supported:
* MHI2_ER_VWG13_K4525_MU1367 - full VC support tested
* MHI2_ER_VWG11_K3342_MU1427 - navigation working on AA and internal tested (no vc was connected) 

I'm hoping that most / all similar MU versions for any brand will also work, but don't know yet.

![image](https://user-images.githubusercontent.com/3318786/147910083-45394825-9a1f-4623-b0ea-c6dc7e6b5dad.png)
