### PR TITLE
Add GEM entry to uninstall the patch/command to ignore smartphone navigating status.

### DIFF
--- a/Toolbox/GEM/mqb-navigation.esd
+++ b/Toolbox/GEM/mqb-navigation.esd
@@ -46,6 +46,10 @@ script
    value   sys 1 0x0100 "/eso/hmi/engdefs/scripts/mqb/install_nav_active_ignore.sh"
    label   "Ignore navigation-active status from smartphone"
 
+script
+   value    sys 1 0x0100 "/eso/hmi/engdefs/scripts/mqb/uninstall_nav_active_ignore.sh"
+   label    "Uninstall Ignore navigation-active"  
+
 
 keyValue
     value   String sys 0x00000000 0

--- a/Toolbox/scripts/uninstall_nav_active_ignore.sh
+++ b/Toolbox/scripts/uninstall_nav_active_ignore.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+export PATH=/proc/boot:/bin:/usr/bin:/usr/sbin:/sbin:/mnt/app/media/gracenote/bin:/mnt/app/armle/bin:/mnt/app/armle/sbin:/mnt/app/armle/usr/bin:/mnt/app/armle/usr/sbin:$PATH
+
+if [ "$_" = "/bin/on" ]; then BASE="$0"; else BASE="$_"; fi
+SCRIPTDIR=$( cd -P -- "$(dirname -- "$(command -v -- "$BASE")")" && pwd -P )
+
+export LD_LIBRARY_PATH=/net/mmx/mnt/app/root/lib-target:/net/mmx/eso/lib:/net/mmx/mnt/app/usr/lib:/net/mmx/mnt/app/armle/lib:/net/mmx/mnt/app/armle/lib/dll:/net/mmx/mnt/app/armle/usr/lib
+
+mount -uw /mnt/app
+
+JAR_TARGET=/mnt/app/eso/hmi/lsd/jars/
+mkdir -p ${JAR_TARGET}
+
+echo "Removing ${JAR_TARGET}/NavActiveIgnore.jar"
+rm -rf ${JAR_TARGET}/NavActiveIgnore.jar
+
+LSD=/mnt/app/eso/hmi/lsd/lsd.sh
+BU=/mnt/app/eso/hmi/lsd/lsd.sh.bu
+
+if [ -e $BU ]; then
+echo "Restoring ${LSD} from backup"
+mv $BU $LSD
+fi
+
+mount -ur /mnt/app
+echo "Done, please restart headunit"


### PR DESCRIPTION
The patched jar in https://github.com/jilleb/mib2-toolbox/pull/189 is known to cause issues on some units.

Eg. https://github.com/jilleb/mib2-toolbox/issues/197

This PR adds a new entry under the uninstall menu category to uninstall the patch to make it easier for others to test / remove.
![screenshot_uninstall](https://user-images.githubusercontent.com/3318786/152455310-0a09b3f9-0879-4062-8984-dab2cf285ff2.png)

