### PR TITLE
fix directory separators in extract-mcf tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /Custom/id_rsa.pub
 Tools/__pycache__/six.cpython-39.pyc
 Tools/__pycache__/configobj.cpython-39.pyc
+.DS_Store

--- a/Tools/extract-mcf.py
+++ b/Tools/extract-mcf.py
@@ -59,7 +59,7 @@ if magic != str('MCF').encode("UTF-8"):  # corresponds to MCF file starting
     sys.exit(1)
 
 filepath, filename = os.path.split(mcf_path)
-idmap_path = filepath + "\imageidmap.res"
+idmap_path = os.path.join(filepath, "imageidmap.res")
 parse_idmap = "n"
 if os.path.exists(idmap_path):
 	print("Imageidmap found, so you can extract files to the right name/folder")
@@ -106,7 +106,7 @@ if (parse_idmap == "y"):
 		path_len = (path_len * 2)
 		# read the path, for as long as the lenght of this string
 		path = read(path_len).decode('utf-16')
-		filename_array.append(path.replace("/", "\\"))
+		filename_array.append(path.replace("/", os.sep))
 		seek(4, 1)
 		i = i + 1
 
@@ -185,7 +185,7 @@ if parse_idmap == "y":
 	while j < num_mifIDs2:
 		id = mifid_array[j]
 		originalfilepath = os.path.join(out_dir_unsorted, 'img_%d.png' % id)
-		newfilepath = new_path = out_dir + "Images\\" + filename_array[j]
+		newfilepath = new_path = os.path.join(out_dir, "Images", filename_array[j])
 		pngfilepath, pngfilename = os.path.split(newfilepath)
 		print("Copying img_%d.png to %s" % (j, newfilepath))
 		if not os.path.exists(pngfilepath):


### PR DESCRIPTION
This PR fixes wrong directory separators on MacOS. Without those changes even `imageidmap.res` could not be detected, so all images cannot be sorted. Probably other scripts also needs tweaks, but I haven't used them yet.

I will appreciate testing those changes on Linux or Windows. Also added `.DS_Store` to gitignore to prevent commiting unnecessary files.

Before:
<img width="432" alt="image" src="https://user-images.githubusercontent.com/2657856/171056610-ac30950c-eaa9-4212-99d0-abb8a5e05425.png">

After:
<img width="951" alt="image" src="https://user-images.githubusercontent.com/2657856/171056267-0fd6f86f-299a-4d54-a823-466eb58268ae.png">
