### PR TITLE
Add advanced command to enable/disable java (hmi) logging to SD1.

### DIFF
--- a/Toolbox/GEM/mqb-advanced.esd
+++ b/Toolbox/GEM/mqb-advanced.esd
@@ -91,3 +91,19 @@ keyValue
 script
    value    sys 1 0x0100 "/eso/hmi/engdefs/scripts/mqb/sshd_install.sh"
    label    "Install SSHD service"  
+keyValue
+    value   String sys 0x00000000 0
+    label   ""
+    poll    0  
+
+keyValue
+    value   String sys 0x00000000 0
+    label   "Enable Java (HMI) Logging to SD1."
+    poll    0  
+    
+script
+   value    sys 1 0x0100 "/eso/hmi/engdefs/scripts/mqb/install_java_logging.sh"
+   label    "Enable Java Logging"  
+script
+   value    sys 1 0x0100 "/eso/hmi/engdefs/scripts/mqb/uninstall_java_logging.sh"
+   label    "Disable Java Logging"  

--- a/Toolbox/scripts/install_java_logging.sh
+++ b/Toolbox/scripts/install_java_logging.sh
@@ -1,0 +1,85 @@
+#!/bin/sh
+export PATH=/proc/boot:/bin:/usr/bin:/usr/sbin:/sbin:/mnt/app/media/gracenote/bin:/mnt/app/armle/bin:/mnt/app/armle/sbin:/mnt/app/armle/usr/bin:/mnt/app/armle/usr/sbin:$PATH
+
+if [ "$_" = "/bin/on" ]; then BASE="$0"; else BASE="$_"; fi
+SCRIPTDIR=$( cd -P -- "$(dirname -- "$(command -v -- "$BASE")")" && pwd -P )
+
+export LD_LIBRARY_PATH=/net/mmx/mnt/app/root/lib-target:/net/mmx/eso/lib:/net/mmx/mnt/app/usr/lib:/net/mmx/mnt/app/armle/lib:/net/mmx/mnt/app/armle/lib/dll:/net/mmx/mnt/app/armle/usr/lib
+
+. ${SCRIPTDIR}/util_mountsd.sh
+if [[ -z "$VOLUME" ]] 
+then
+  echo "No SD-card found, quitting"
+  exit 0
+fi
+
+mount -uw /mnt/app
+
+
+RUN_HMI=/mnt/app/eso/bin/runHMI.sh
+RUN_HMI_WRAPPER=${RUN_HMI}.real
+
+if [ ! -e ${RUN_HMI} ]; then
+  echo "ERROR: ${RUN_HMI} not found, cannot enable java logging on this version"
+
+else
+
+if [ ! -e ${RUN_HMI_WRAPPER} ]; then
+  cp -v ${RUN_HMI} ${RUN_HMI_WRAPPER}
+fi
+
+echo "Installing logging wrapper for ${RUN_HMI}"
+
+cat << "EOF" > ${RUN_HMI}
+#!/bin/sh
+#
+# runHMI.sh wrapper to add logging to SD1
+#
+# run as:
+# > cd /mnt/app/eso
+# > . bin/runHMI.sh
+
+RUN_HMI_REAL="${_}.real"
+
+waitfor /fs/sda0 5 > /dev/null 2>&1
+
+logtarget=/dev/null
+
+if [ -d /fs/sda0/Logs ]; then
+    mount -uw /fs/sda0
+    logtarget=/fs/sda0/Logs/mmxlog.txt
+    if [ -e ${logtarget}.1 ]; then
+        mv ${logtarget}.1 ${logtarget}.2
+    fi
+    if [ -e ${logtarget} ]; then
+        mv ${logtarget} ${logtarget}.1
+    fi
+fi
+
+if command -v tee > /dev/null 2>&1
+then    
+    echo "Running ${RUN_HMI_REAL} with tee to ${logtarget}" >${logtarget}
+    . ${RUN_HMI_REAL} "$@" 2>&1 | tee -a ${logtarget}
+else
+    echo "Running ${RUN_HMI_REAL} with output to ${logtarget}" >${logtarget}
+    . ${RUN_HMI_REAL} "$@" >> ${logtarget} 2>&1
+fi
+EOF
+
+fi
+
+if [ ! -e ${VOLUME}/Logs ]; then
+  echo "Creating Logs folder on SD"
+  mkdir -p ${VOLUME}/Logs
+fi
+
+mount -ur /mnt/app
+
+if [ ! -e /net/mmx/fs/sda0 ]; then
+ echo "It looks like your SD card is in SD2, it must be in SD1 to use logging"
+fi
+
+
+echo ""
+echo "After reboot, mmx logs will be in SD1 Logs folder."
+echo "Done, please restart headunit"

--- a/Toolbox/scripts/uninstall_java_logging.sh
+++ b/Toolbox/scripts/uninstall_java_logging.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+export PATH=/proc/boot:/bin:/usr/bin:/usr/sbin:/sbin:/mnt/app/media/gracenote/bin:/mnt/app/armle/bin:/mnt/app/armle/sbin:/mnt/app/armle/usr/bin:/mnt/app/armle/usr/sbin:$PATH
+
+if [ "$_" = "/bin/on" ]; then BASE="$0"; else BASE="$_"; fi
+SCRIPTDIR=$( cd -P -- "$(dirname -- "$(command -v -- "$BASE")")" && pwd -P )
+
+export LD_LIBRARY_PATH=/net/mmx/mnt/app/root/lib-target:/net/mmx/eso/lib:/net/mmx/mnt/app/usr/lib:/net/mmx/mnt/app/armle/lib:/net/mmx/mnt/app/armle/lib/dll:/net/mmx/mnt/app/armle/usr/lib
+
+mount -uw /mnt/app
+
+RUN_HMI=/mnt/app/eso/bin/runHMI.sh
+RUN_HMI_WRAPPER=${RUN_HMI}.real
+
+if [ -e ${RUN_HMI_WRAPPER} ]; then
+echo "Restoring ${RUN_HMI} back to original"
+mv ${RUN_HMI_WRAPPER} ${RUN_HMI}
+fi
+
+mount -ur /mnt/app
+echo "Done, please restart headunit"


### PR DESCRIPTION
In Harman units the main application running to manage the UI interface any most of the functions behind it are running in a Java application.
The logging output from this app can be very useful when diagnosing issues, or developing patches like https://github.com/jilleb/mib2-toolbox/pull/189

While there are multiple different "trace" systems in the MIB units for getting log data out, they're in formats that I've been unable to decode and/or get useful information out of.

This command / script goes the blunt force route of adding a wrapper script into the startup commands used to run the Java application on boot and simply redirects the console output from the java app to a regular text log file on SD card.

For reference, the boot system runs these sequence of scripts 
* /etc/boot/startup.sh
* /mnt/app/eso/bin/runHMI.sh
* /mnt/app/eso/hmi/lsd/lsd.sh

`lsd.sh` is the one that actually runs the Java app via the `j9` runtime. `runHMI.sh` in the middle is already a rather small wrapper script to interface between the two. It's this one I add a new wrapper script around making the startup look like
* /etc/boot/startup.sh
* /mnt/app/eso/bin/runHMI.sh
* /mnt/app/eso/bin/runHMI.sh.real
* /mnt/app/eso/hmi/lsd/lsd.sh

With this change in place, after a reboot, the unit will pause briefly during startup until SD1 is mounted (can take a second or two) then run the main GUI java app with all logging output redirected to the file `Logs/mmxlog.txt` on the SD card.

If no SD card is inserted, startup will be delayed ~5 seconds while it looks for one, so you might not want to leave this patch in place permanently if SD card is not used. 
The actual logging to card could also slow down the unit slightly, though I haven't noticed much myself.

With this startup patch you'll get a fair bit of the internal logging coming out, though the standard log levels isn't very verbose.
There are ways to adjust the verbosity of different module in use, but I’m not certain which method actually works.
Can try changing things in these files:
```
/eso/hmi/lsd/config/logging.properties
/eso/hmi/lsd/traceConfig.properties
```
Also in the service screens on the unit, there's places to set trace levels for logging domains - I'm not sure if setting things there helps as well.
