### PR TITLE
Fix composition media spelling

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -24,7 +24,7 @@ Customize your MIB2HIGH unit graphics, patch Android Auto so it can run custom a
 - No. That's a SWaP feature, and your dealer is happy to help you.
 
 ## Why do I get a variant-conflict error?
-- This happens when you tried installing it on a non MIB2-HIGH system. It will **not** work on MIB1 or MIB2 Standard units. Discover Media / Compostion Media is not MIB2 HIGH!
+- This happens when you tried installing it on a non MIB2-HIGH system. It will **not** work on MIB1 or MIB2 Standard units. Discover Media / Composition Media is not MIB2 HIGH!
 
 ## Why do I get a "script not found" error?
 - Make sure you are using the latest version of the script.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Note3: If you're a business that tries to make a profit off of this:  Don't be a
 # Requirements
 - Read the entire readme
 - At least 1 healthy set of brains
-- An MIB2 HIGH or MIB2.5 HIGH infotainment unit. It will **not** work on MIB1 or MIB2 Standard units. Discover Media / Compostion Media is not MIB2 HIGH! For MIB2 Standard see the [olli991/mib-std2-pq-zr-toolbox](https://github.com/olli991/mib-std2-pq-zr-toolbox) project.
+- An MIB2 HIGH or MIB2.5 HIGH infotainment unit. It will **not** work on MIB1 or MIB2 Standard units. Discover Media / Composition Media is not MIB2 HIGH! For MIB2 Standard see the [olli991/mib-std2-pq-zr-toolbox](https://github.com/olli991/mib-std2-pq-zr-toolbox) project.
 - 1 empty, **FAT32 formatted** SD-card, with enough space. Everything bigger than 1GB is fine
 - Some place to save your backups
 


### PR DESCRIPTION
## Summary
- fix spelling of Composition Media in README and FAQ

## Testing
- `grep -n "Composition Media" -n README.md FAQ.md`

------
https://chatgpt.com/codex/tasks/task_e_686683857e848329a176b6cfd71c09bb