### PR TITLE
Fix spelling in patch scripts

### DIFF
--- a/Toolbox/scripts/patch_vim06.sh
+++ b/Toolbox/scripts/patch_vim06.sh
@@ -47,7 +47,7 @@ if [ ! -z $VIM 2>/dev/null ]; then
 			echo "Calculating new checksum"
 			# Include CRC utility
 			. /eso/hmi/engdefs/scripts/mqb/util_crc16.sh $VIMPATCH
-			# Patching persistence adress 
+                        # Patching persistence address
 			VIMPATCH=$VIMPATCH$crcsum
 			on -f mmx /net/mmx/eso/bin/apps/pc b:0:3221422082 $VIMPATCH
 			on -f mmx /net/mmx/eso/bin/apps/pc b:0:1 0

--- a/Toolbox/scripts/patch_vim199.sh
+++ b/Toolbox/scripts/patch_vim199.sh
@@ -47,7 +47,7 @@ if [ ! -z $VIM 2>/dev/null ]; then
 			echo "Calculating new checksum"
 			# Include CRC utility
 			. /eso/hmi/engdefs/scripts/mqb/util_crc16.sh $VIMPATCH
-			# Patching persistence adress 
+                        # Patching persistence address
 			VIMPATCH=$VIMPATCH$crcsum
 			on -f mmx /net/mmx/eso/bin/apps/pc b:0:3221422082 $VIMPATCH
 			on -f mmx /net/mmx/eso/bin/apps/pc b:0:1 0

--- a/Toolbox/scripts/patch_vim_advanced.sh
+++ b/Toolbox/scripts/patch_vim_advanced.sh
@@ -10,7 +10,7 @@ export DESCRIPTION="This script will patch VIM"
 VIM=$(on -f mmx /eso/bin/dumb_persistence_reader 0 3221422082 2> /dev/null)
 VIM=$(echo $VIM | awk '{print toupper($0)}')  
 
-echo "This script will patch VIM to custom choosen variables"
+echo "This script will patch VIM to custom chosen variables"
 
 # Include info script
 . /eso/hmi/engdefs/scripts/mqb/util_info.sh


### PR DESCRIPTION
## Summary
- correct spelling of "address" in `patch_vim199.sh` and `patch_vim06.sh`
- correct spelling of "chosen" in `patch_vim_advanced.sh`

## Testing
- `sh -n Toolbox/scripts/patch_vim199.sh`
- `sh -n Toolbox/scripts/patch_vim06.sh`
- `sh -n Toolbox/scripts/patch_vim_advanced.sh`


------
https://chatgpt.com/codex/tasks/task_e_686683a544e08329a2be03c5462d7d73